### PR TITLE
Fix lag of many YouTube videos on a page

### DIFF
--- a/themes/hugo-book/layouts/shortcodes/youtube.html
+++ b/themes/hugo-book/layouts/shortcodes/youtube.html
@@ -1,0 +1,10 @@
+{{- $pc := .Page.Site.Config.Privacy.YouTube -}}
+{{- if not $pc.Disable -}}
+{{- $ytHost := cond $pc.PrivacyEnhanced  "www.youtube-nocookie.com" "www.youtube.com" -}}
+{{- $id := .Get "id" | default (.Get 0) -}}
+{{- $class := .Get "class" | default (.Get 1) -}}
+{{- $title := .Get "title" | default "YouTube Video" }}
+<div {{ with $class }}class="{{ . }}"{{ else }}style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden;"{{ end }}>
+    <iframe src="https://{{ $ytHost }}/embed/{{ $id }}{{ with .Get "autoplay" }}{{ if eq . "true" }}?autoplay=1{{ end }}{{ end }}" {{ if not $class }}style="position: absolute; top: 0; left: 0; width: 100%; height: 100%; border:0;" {{ end }}allowfullscreen title="{{ $title }}" loading="lazy"></iframe>
+</div>
+{{ end -}}


### PR DESCRIPTION
Add a modified copy of the original Hugo 'youtube' shortcode which enables lazy iframe loading.
Now, the YouTube player is loaded when it has become visible to the visitor.