### PR TITLE
Lightning features

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -40,7 +40,7 @@ menu:
 
 params:
   # Site Lightning address to receive donations.
-  LightningAddress: "21ideas@getalby.com"
+  LightningAddress: "tony@bitcoin-herald.org"
 
   # (Optional, default light) Sets color theme: light, dark or auto.
   # Theme 'auto' switches between dark and light modes based on browser/os preferences

--- a/config.yaml
+++ b/config.yaml
@@ -39,6 +39,9 @@ menu:
       weight: 10
 
 params:
+  # Site Lightning address to receive donations.
+  LightningAddress: "21ideas@getalby.com"
+
   # (Optional, default light) Sets color theme: light, dark or auto.
   # Theme 'auto' switches between dark and light modes based on browser/os preferences
   BookTheme: "auto"

--- a/content.ru/docs/Contribute/_index.md
+++ b/content.ru/docs/Contribute/_index.md
@@ -18,7 +18,7 @@ weight: 5
 
 Проект 21ideas является некоммерческим и годами существует благодаря упорству и средствам его основателя, а также поддерке участников сообщества. Поддержание проекта - от написания и перевода статей до модерации библиотеки - требует ресурсов. Вы можете поддержать проект несколькими способами:
 
-{{</* columns */>}} 
+{{< columns >}} 
 ## Биткоин
 Биткоин-адрес: `bc1q805dq3u6t76nd5av3jdln0vy6zxt4y5djem4s5`
 
@@ -43,9 +43,11 @@ _[tony@bitcoin-herald.org](lightning:tony@bitcoin-herald.org)_
 Email: [lightning_tony@protonmail.com](mailto:lightning_tony@protonmail.com)
 
 Nostr: [Tony@bitcoin-herald.org](https://snort.social/p/npub10awzknjg5r5lajnr53438ndcyjylgqsrnrtq5grs495v42qc6awsj45ys7)
-{{</* /columns */>}}
+{{< /columns >}}
 
 Вы также можете указать цель, на которую вы бы хотели определить отправленные средства - будь то перевод или написание определенной статьи, либо какие-либо улучшения ресурса. Подробнее об этом - в [README](https://github.com/21ideas-org/21ideas.org#readme) файле на нашем GitHub.
+
+{{< lightningwidget >}}
 
 {{< /tab >}}
 

--- a/themes/hugo-book/layouts/partials/docs/html-head.html
+++ b/themes/hugo-book/layouts/partials/docs/html-head.html
@@ -3,6 +3,7 @@
 <meta name="description" content="{{ default .Summary .Description }}">
 <meta name="theme-color" content="#FFFFFF">
 <meta name="color-scheme" content="light dark">
+<meta name="lightning" content="{{ .Site.Params.LightningAddress }}">
 
 {{- with .Page.Params.BookHref -}}
   <meta http-equiv="Refresh" content="0; url='{{ . }}'" />

--- a/themes/hugo-book/layouts/shortcodes/lightningwidget.html
+++ b/themes/hugo-book/layouts/shortcodes/lightningwidget.html
@@ -1,0 +1,10 @@
+<div>
+  <lightning-widget 
+    name="{{ .Site.Title }}" 
+    accent="#ff9500" 
+    to="{{ .Site.Params.LightningAddress}}" 
+    image="{{ .Site.Params.BookLogo }}" 
+    amounts="1000,10000,100000"
+    labels="🍬,☕️,🍝" />
+</div>
+<script src="https://embed.twentyuno.net/js/app.js"></script>


### PR DESCRIPTION
This PR adds some Lightning features to the site:
- `lightning` meta tag with the donation address, which activates Lightning browser wallet (Alby) and allows sending sats from it;
- `lightningwidget` shortcode for the twentyuno Lightning widget to embed wherever it is suitable. I've already added it to the contribution page.

![Снимок экрана 2023-09-18 124801](https://github.com/21ideas-org/21ideas.org/assets/5675681/986cedea-f03c-43e0-9df7-99e79e9d864c)
![Web capture_18-9-2023_12477_localhost](https://github.com/21ideas-org/21ideas.org/assets/5675681/7cf96a6f-f297-4073-beaa-f0c3bc0c7971)
