### PR TITLE
Fix not localized post date format

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -1,7 +1,7 @@
 baseURL: 'https://new.21ideas.org/'
 theme: hugo-book
 title: 21ideas
-defaultContentLanguage: "ru"
+defaultContentLanguage: ru
 
 ignoreErrors: ["error-remote-getjson"]
 
@@ -28,6 +28,7 @@ languages:
   #   weight: 2
   ru:
     languageName: Russian
+    languageCode: ru-RU
     contentDir: content.ru
     weight: 1
 
@@ -84,8 +85,8 @@ params:
 
   # Configure the date format used on the pages
   # - In git information
-  # - In blog posts
-  BookDateFormat: "January 2, 2006"
+  # To configure format in blog posts with multilang support, see "post-meta.html"
+  BookDateFormat: "2 January 2006"
 
   # (Optional, default true) Enables search function with flexsearch,
   # Index is built on fly, therefore it might slowdown your website.

--- a/themes/hugo-book/layouts/partials/docs/post-meta.html
+++ b/themes/hugo-book/layouts/partials/docs/post-meta.html
@@ -1,6 +1,4 @@
-{{ with .Date }}
-  <h5>{{ partial "docs/date" (dict "Date" . "Format" $.Site.Params.BookDateFormat) }}</h5>
-{{ end }}
+<h5>{{ .Date | time.Format ":date_long" }}</h5>
 
 {{ range $taxonomy, $_ := .Site.Taxonomies }}
   {{ with $terms := $.GetTerms $taxonomy }}


### PR DESCRIPTION
Now, the post date is localized according to the content language:
![image](https://github.com/21ideas-org/21ideas.org/assets/5675681/31b0777d-fe50-43a0-a293-bf9990ae7431)
