### PR TITLE
Add a separate category for Bitcoin herald

### DIFF
--- a/content.ru/docs/Contribute/_index.md
+++ b/content.ru/docs/Contribute/_index.md
@@ -8,7 +8,7 @@ weight: 5
 bookhidden: true
 menu:
   after:
-    weight: 2
+    weight: 3
     params:
       children: true
 ---

--- a/content.ru/vestnik/825769.md
+++ b/content.ru/vestnik/825769.md
@@ -2,15 +2,11 @@
 author: "tony"
 date: 2024-01-14
 list_description: "Важнейшие Биткоин-события недели: Bitcoin ETF одобрен, биткоин не попадет на Луну, релизы, многое другое."
-menu:
-  main:
-    parent: blog
-next: /blog/
-prev: /blog/ledger-attack
 title: "Биткоин-вестник: неделя 2"
 description: "Важнейшие Биткоин-события недели: Bitcoin ETF одобрен, биткоин не попадет на Луну, релизы, многое другое."
 cover: /img/herald/24-02/02.png
-weight: 10
+
+aliases: ['posts/vestnik-02/'] # This issue was originaly published in the blog. Do not use this property in further issues.
 ---
 
   

--- a/content.ru/vestnik/_index.md
+++ b/content.ru/vestnik/_index.md
@@ -1,0 +1,13 @@
+---
+menu:
+  after:
+    weight: 2
+title: Биткоин-вестник
+description: "Еженедельний дайджест новостей о Биткоине, деньгах и свободе."
+cover: "/img/herald/main/banner-grey.png"
+
+# This content is not rendered to the visitors 
+# but used when pasting category link to Telegram.
+---
+
+Еженедельний дайджест новостей о Биткоине, деньгах и свободе.

--- a/themes/hugo-book/layouts/vestnik/list.html
+++ b/themes/hugo-book/layouts/vestnik/list.html
@@ -1,0 +1,42 @@
+{{ define "main" }}
+<div class="pageCover">
+  <picture>
+    <source srcset="/img/herald/main/banner-grey.png" media="(prefers-color-scheme: dark)">
+    <img src="/img/herald/main/banner-white.png" alt="Cover" />
+  </picture>
+</div>
+<center>
+  Еженедельний дайджест новостей о Биткоине, деньгах и свободе.
+</center>
+<br>
+<hr>
+<br>
+
+{{ range sort .Paginator.Pages }}
+<article class="markdown book-post">
+  {{- with .Params.Cover }}
+  <div class="book-post_cover">
+    <img src="{{ . }}">
+  </div>
+  {{- end }}
+  <h2>
+    <a href="{{ .RelPermalink }}">{{ partial "docs/title.html" . }}</a>
+  </h2>
+  <div class="book-post_date">
+    {{ .Date | time.Format ":date_long" }}
+  </div>
+  {{- with .Params.list_description }}
+  <p>{{ . }}</p>
+  {{- end }}
+  <p>
+    <a href="{{ .RelPermalink }}">Читать выпуск →</a>
+  </p>
+</article>
+{{ end }}
+
+{{ template "_internal/pagination.html" . }}
+{{ end }}
+
+{{ define "toc" }}
+{{ partial "docs/taxonomy" . }}
+{{ end }}

--- a/themes/hugo-book/layouts/vestnik/single.html
+++ b/themes/hugo-book/layouts/vestnik/single.html
@@ -1,0 +1,11 @@
+{{ define "main" }}
+{{ partial "page-header.html" . }}
+<article class="markdown">
+  {{- .Content -}}
+</article>
+{{ partial "docs/comments.html" . }}
+{{ end }}
+
+{{ define "toc" }}
+  {{ partial "docs/toc" . }}
+{{ end }}


### PR DESCRIPTION
- The first 2024 issue has been moved to the new category, but its URL remains the same.

![image](https://github.com/21ideas-org/21ideas.org/assets/5675681/db477a91-fd0d-4b59-84b5-de71e074dfc6)
