### PR TITLE
GH-251 Update Zap Threads to 0.5.1

### DIFF
--- a/themes/hugo-book/layouts/partials/docs/html-head.html
+++ b/themes/hugo-book/layouts/partials/docs/html-head.html
@@ -60,4 +60,4 @@ https://github.com/alex-shpak/hugo-book
   {{- end -}}
 {{- end -}}
 
-<script type="text/javascript" src="https://unpkg.com/zapthreads@0.5.0/dist/zapthreads.iife.js"></script>
+<script type="text/javascript" src="https://unpkg.com/zapthreads@0.5.1/dist/zapthreads.iife.js"></script>


### PR DESCRIPTION
This must fix not posting comments when the URL contains a fragment (#)