### PR TITLE
Update Zap Threads to 0.5.2

### DIFF
--- a/themes/hugo-book/layouts/partials/docs/comments.html
+++ b/themes/hugo-book/layouts/partials/docs/comments.html
@@ -7,4 +7,5 @@
       author="npub1lm3f47nzyf0rjp6fsl4qlnkmzed4uj4h2gnf2vhe3l3mrj85vqks6z3c7l"
       relays="wss://21ideas.nostr1.com"
       disable="replyAnonymously"
+      legacy-url="true"
       />

--- a/themes/hugo-book/layouts/partials/docs/html-head.html
+++ b/themes/hugo-book/layouts/partials/docs/html-head.html
@@ -60,4 +60,4 @@ https://github.com/alex-shpak/hugo-book
   {{- end -}}
 {{- end -}}
 
-<script type="text/javascript" src="https://unpkg.com/zapthreads@0.5.1/dist/zapthreads.iife.js"></script>
+<script type="text/javascript" src="https://unpkg.com/zapthreads@0.5.2/dist/zapthreads.iife.js"></script>


### PR DESCRIPTION
Use `legacy-url` flag to overcome current relay issue. 
https://github.com/fr4nzap/zapthreads/issues/44#issuecomment-2043030151