### PR TITLE
enhancement: Add JSON-LD, llms.txt outputs, and crawl metadata

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -3,6 +3,11 @@ theme: hugo-book
 title: 21ideas
 defaultContentLanguage: ru
 
+sitemap:
+  changefreq: weekly
+  priority: 0.5
+  filename: sitemap.xml
+
 ignoreErrors: ["error-remote-getjson"]
 
 include: [".well-known"]
@@ -112,4 +117,21 @@ params:
   # (Optional, experimental, default false) Enables a drop-down menu for translations only if a translation is present.
   BookTranslatedOnly: false
 
+outputFormats:
+  llms:
+    mediaType: text/plain
+    baseName: llms
+    isPlainText: true
+    notAlternative: true
+  llmsfull:
+    mediaType: text/plain
+    baseName: llms-full
+    isPlainText: true
+    notAlternative: true
 
+outputs:
+  home:
+    - HTML
+    - RSS
+    - llms
+    - llmsfull

--- a/layouts/index.llms.txt
+++ b/layouts/index.llms.txt
@@ -1,0 +1,16 @@
+# {{ .Site.Title }}
+
+> {{ with .Description }}{{ . }}{{ else }}Образовательный ресурс о Биткоине / Bitcoin educational resource{{ end }}
+
+{{ range .Site.Sections -}}
+## {{ .Title }}
+{{ range .Pages -}}
+- [{{ default .RelPermalink .LinkTitle }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{ end -}}
+{{ range .Sections -}}
+### {{ .Title }}
+{{ range .Pages -}}
+- [{{ default .RelPermalink .LinkTitle }}]({{ .Permalink }}){{ with .Description }}: {{ . }}{{ end }}
+{{ end -}}
+{{ end -}}
+{{ end }}

--- a/layouts/index.llmsfull.txt
+++ b/layouts/index.llmsfull.txt
@@ -1,0 +1,27 @@
+# {{ .Site.Title }}
+
+> {{ with .Description }}{{ . }}{{ else }}Образовательный ресурс о Биткоине / Bitcoin educational resource{{ end }}
+
+{{ range .Site.Sections -}}
+## {{ .Title }}
+{{ range .Pages -}}
+### [{{ default .RelPermalink .LinkTitle }}]({{ .Permalink }})
+{{ with .Description }}> {{ . }}
+
+{{ end -}}
+{{ end -}}
+{{ range .Sections -}}
+### {{ .Title }}
+{{ range .Pages -}}
+#### [{{ default .RelPermalink .LinkTitle }}]({{ .Permalink }})
+{{ with .Description }}> {{ . }}
+
+{{ end -}}
+{{- /* Inline full plaintext for Start and Theory subsections only */ -}}
+{{- if or (in .CurrentSection.RelPermalink "/start/") (in .CurrentSection.RelPermalink "/theory/") (in .CurrentSection.RelPermalink "/practice/") -}}
+{{ .Content | plainify }}
+
+{{ end -}}
+{{ end -}}
+{{ end -}}
+{{ end }}

--- a/layouts/partials/docs/inject/head.html
+++ b/layouts/partials/docs/inject/head.html
@@ -1,4 +1,9 @@
 <meta name="robots" content="index, follow">
 <link rel="canonical" href="{{ .Permalink }}">
 
+{{ with .Params.tags }}
+<meta name="keywords" content="{{ delimit . ", " }}">
+{{ end }}
+
 <script defer src="https://cloud.umami.is/script.js" data-website-id="0affba7d-3c1d-4235-adb3-635b69b6f567"></script>
+{{ partial "docs/inject/structured-data.html" . }}

--- a/layouts/partials/docs/inject/structured-data.html
+++ b/layouts/partials/docs/inject/structured-data.html
@@ -1,0 +1,33 @@
+{{- /* BreadcrumbList — all non-home pages */ -}}
+{{- if not .IsHome -}}
+{{- $items := slice -}}
+{{- range $i, $a := .Ancestors.Reverse -}}
+  {{- $items = $items | append (dict "@type" "ListItem" "position" (add $i 1) "name" $a.Title "item" $a.Permalink) -}}
+{{- end -}}
+{{- $items = $items | append (dict "@type" "ListItem" "position" (add (len .Ancestors) 1) "name" .Title "item" .Permalink) -}}
+{{- $ld := dict "@context" "https://schema.org" "@type" "BreadcrumbList" "itemListElement" $items -}}
+<script type="application/ld+json">{{ $ld | jsonify | safeJS }}</script>
+{{- end -}}
+
+{{- /* WebSite + Organization — home page only */ -}}
+{{- if .IsHome -}}
+{{- $action := dict "@type" "SearchAction" "target" (dict "@type" "EntryPoint" "urlTemplate" (printf "%ssearch/?q={search_term_string}" .Site.BaseURL)) "query-input" "required name=search_term_string" -}}
+{{- $website := dict "@context" "https://schema.org" "@type" "WebSite" "url" .Site.BaseURL "name" .Site.Title "potentialAction" $action -}}
+<script type="application/ld+json">{{ $website | jsonify | safeJS }}</script>
+{{- $logo := dict "@type" "ImageObject" "url" (printf "%ssvg/logo_black.svg" .Site.BaseURL) -}}
+{{- $org := dict "@context" "https://schema.org" "@type" "Organization" "url" .Site.BaseURL "name" .Site.Title "logo" $logo "sameAs" (slice "https://github.com/21ideas-org/21ideas.org") -}}
+<script type="application/ld+json">{{ $org | jsonify | safeJS }}</script>
+{{- end -}}
+
+{{- /* Article — posts and vestnik section pages (not section index pages) */ -}}
+{{- if and (or (eq .Section "posts") (eq .Section "vestnik")) (not .IsSection) -}}
+{{- $publisher := dict "@type" "Organization" "name" .Site.Title "logo" (dict "@type" "ImageObject" "url" (printf "%ssvg/logo_black.svg" .Site.BaseURL)) -}}
+{{- $ld := dict "@context" "https://schema.org" "@type" "Article" "headline" .Title "description" .Description "datePublished" (.Date.Format "2006-01-02") "dateModified" (.Lastmod.Format "2006-01-02") "url" .Permalink "publisher" $publisher -}}
+{{- with .Params.author -}}
+  {{- $ld = merge $ld (dict "author" (dict "@type" "Person" "name" .)) -}}
+{{- end -}}
+{{- with .Params.cover -}}
+  {{- $ld = merge $ld (dict "image" (printf "%s%s" (trim $.Site.BaseURL "/") .)) -}}
+{{- end -}}
+<script type="application/ld+json">{{ $ld | jsonify | safeJS }}</script>
+{{- end -}}

--- a/static/robots.txt
+++ b/static/robots.txt
@@ -1,3 +1,47 @@
 User-agent: *
 Allow: /
 Sitemap: https://21ideas.org/sitemap.xml
+
+# Search engines (explicit)
+User-agent: Googlebot
+Allow: /
+
+User-agent: bingbot
+Allow: /
+
+User-agent: YandexBot
+Allow: /
+
+# OpenAI
+User-agent: GPTBot
+Allow: /
+
+User-agent: OAI-SearchBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+# Anthropic
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-SearchBot
+Allow: /
+
+User-agent: Claude-User
+Allow: /
+
+# Perplexity
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Perplexity-User
+Allow: /
+
+# Google AI (Gemini/Vertex AI training crawler control)
+User-agent: Google-Extended
+Allow: /
+
+# AI-readable index
+# llms.txt: https://21ideas.org/llms.txt


### PR DESCRIPTION
Inject JSON-LD (WebSite/Organization/BreadcrumbList/Article), generate llms.txt + llms-full.txt via Hugo output formats, add sitemap changefreq/priority, expand robots.txt for major search/AI crawlers, and emit keywords meta from front matter tags.